### PR TITLE
[Update]: Commit new error message API and needed refactoring

### DIFF
--- a/src/OtterkitAnalyzer/Analyzer.Helpers.cs
+++ b/src/OtterkitAnalyzer/Analyzer.Helpers.cs
@@ -136,26 +136,16 @@ public static partial class Analyzer
 
     private static void AnchorPoint(params string[] anchors)
     {
-        ErrorHandler.Analyzer.AttemptRecovery(anchors);
-
         while (!CurrentEquals(TokenType.EOF))
         {
             if (CurrentEquals("."))
             {
-                ErrorHandler.Analyzer.Report(FileName, Current(), ErrorType.Recovery, """
-                Parser recovered at the following anchor point: 
-                """);
-                ErrorHandler.Analyzer.PrettyError(FileName, Current(), ConsoleColor.Blue);
                 Continue();
                 return;
             }
 
             if (CurrentEquals(anchors))
             {
-                ErrorHandler.Analyzer.Report(FileName, Current(), ErrorType.Recovery, """
-                Parser recovered at the following anchor point: 
-                """);
-                ErrorHandler.Analyzer.PrettyError(FileName, Current(), ConsoleColor.Blue);
                 return;
             }
 
@@ -165,26 +155,16 @@ public static partial class Analyzer
 
     private static void AnchorPoint(TokenContext anchor)
     {
-        ErrorHandler.Analyzer.AttemptRecovery(anchor);
-
         while (!CurrentEquals(TokenType.EOF))
         {
             if (CurrentEquals("."))
             {
-                ErrorHandler.Analyzer.Report(FileName, Current(), ErrorType.Recovery, """
-                Parser recovered at the following anchor point: 
-                """);
-                ErrorHandler.Analyzer.PrettyError(FileName, Current(), ConsoleColor.Blue);
                 Continue();
                 return;
             }
 
             if (CurrentEquals(anchor))
             {
-                ErrorHandler.Analyzer.Report(FileName, Current(), ErrorType.Recovery, """
-                Parser recovered at the following anchor point: 
-                """);
-                ErrorHandler.Analyzer.PrettyError(FileName, Current(), ConsoleColor.Blue);
                 return;
             }
 
@@ -194,26 +174,16 @@ public static partial class Analyzer
 
     private static void CombinedAnchorPoint(TokenContext anchor, params string[] anchors)
     {
-        ErrorHandler.Analyzer.AttemptRecovery(anchors);
-
         while (!CurrentEquals(TokenType.EOF))
         {
             if (CurrentEquals("."))
             {
-                ErrorHandler.Analyzer.Report(FileName, Current(), ErrorType.Recovery, """
-                Parser recovered at the following anchor point: 
-                """);
-                ErrorHandler.Analyzer.PrettyError(FileName, Current(), ConsoleColor.Blue);
                 Continue();
                 return;
             }
 
             if (CurrentEquals(anchors) || CurrentEquals(anchor))
             {
-                ErrorHandler.Analyzer.Report(FileName, Current(), ErrorType.Recovery, """
-                Parser recovered at the following anchor point: 
-                """);
-                ErrorHandler.Analyzer.PrettyError(FileName, Current(), ConsoleColor.Blue);
                 return;
             }
 

--- a/src/OtterkitAnalyzer/Analyzer.cs
+++ b/src/OtterkitAnalyzer/Analyzer.cs
@@ -70,7 +70,7 @@ public static partial class Analyzer
 
         // If a parsing error has occured, terminate the compilation process.
         // We do not want the compiler to continue when the source code is not valid.
-        if (ErrorHandler.Error) ErrorHandler.Terminate("parsing");
+        if (ErrorHandler.HasError) ErrorHandler.Terminate("parsing");
 
         // Return parsed list of tokens.
         return TokenList;

--- a/src/OtterkitCompiler.cs
+++ b/src/OtterkitCompiler.cs
@@ -141,7 +141,7 @@ public static class OtterkitCompiler
 
             if (Options.BuildMode is BuildType.ParseOnly)
             {
-                if (!ErrorHandler.Error) ErrorHandler.SuccessfulParsing();
+                if (!ErrorHandler.HasError) ErrorHandler.SuccessfulParsing();
             }
 
             if (Options.BuildMode is BuildType.PrintTokens)
@@ -163,7 +163,7 @@ public static class OtterkitCompiler
                     Console.WriteLine(token);
                 }
 
-                if (!ErrorHandler.Error) ErrorHandler.SuccessfulParsing();
+                if (!ErrorHandler.HasError) ErrorHandler.SuccessfulParsing();
             }
 
             if (Options.BuildMode is BuildType.PrintSymbols)
@@ -185,7 +185,7 @@ public static class OtterkitCompiler
                     Console.WriteLine($"{symbol.Key}  =>  {symbol.Value.SymbolType}");
                 }
 
-                if (!ErrorHandler.Error) ErrorHandler.SuccessfulParsing();
+                if (!ErrorHandler.HasError) ErrorHandler.SuccessfulParsing();
             }
 
             if (Options.BuildMode is BuildType.BuildOnly)

--- a/src/OtterkitEnums/ErrorType.cs
+++ b/src/OtterkitEnums/ErrorType.cs
@@ -2,6 +2,7 @@ namespace Otterkit;
 
 public enum ErrorType
 {
+    Analyzer,
     General,
     Syntax,
     Expected,

--- a/src/OtterkitErrorHandler/ErrorHandler.cs
+++ b/src/OtterkitErrorHandler/ErrorHandler.cs
@@ -1,0 +1,102 @@
+namespace Otterkit;
+
+public ref struct Error
+{
+    private static ConsoleColor Green = ConsoleColor.Green;
+    private static ConsoleColor DarkGray = ConsoleColor.DarkGray;
+
+    private ErrorType ErrorType;
+    private ConsoleColor ConsoleColor;
+
+    public Error(ErrorType errorType, ConsoleColor consoleColor)
+    {
+        ErrorType = errorType;
+        ConsoleColor = consoleColor;
+    }
+
+    private static void ColoredWrite(ConsoleColor consoleColor, string text)
+    {
+        Console.ForegroundColor = consoleColor;
+        Console.Write(text);
+
+        Console.ResetColor();
+    }
+
+    private static void ColoredWriteLine(ConsoleColor consoleColor, string text)
+    {
+        Console.ForegroundColor = consoleColor;
+        Console.WriteLine(text);
+
+        Console.ResetColor();
+    }
+
+    public static Error Build(ErrorType errorType, ConsoleColor consoleColor, int errorCode, string errorMessage)
+    {
+        Console.OutputEncoding = System.Text.Encoding.UTF8;
+
+        ColoredWrite(consoleColor, $" {errorType} Error [COB{errorCode:D4}]");
+
+        Console.WriteLine($": {errorMessage}");
+
+        return new(errorType, consoleColor);
+    }
+
+    public Error WithSourceLine(Token token, string fileName, string? errorHelp = null)
+    {
+        string line = File.ReadLines(fileName).Skip(token.line - 1).Take(token.line).First();
+        string error = new(' ', line.Length - token.value.Length);
+
+        int count = line.TakeWhile(char.IsWhiteSpace).Count();
+        error = error.Insert(token.column - count, new string('~', token.value.Length));
+        
+        ColoredWrite(DarkGray, "     ╭─/> [");
+
+        Console.Write($"{fileName}:{token.line}:{token.column}");
+
+        ColoredWriteLine(DarkGray, "]");
+
+        ColoredWriteLine(DarkGray, "     │");
+
+        ColoredWrite(DarkGray, $"{token.line,4} │  ");
+
+        Console.WriteLine($"{line.TrimStart()}");
+
+        ColoredWrite(DarkGray, "     │");
+
+        ColoredWrite(ConsoleColor, $"  {error.TrimEnd()}");
+
+        if (errorHelp is not null)
+        {
+            ColoredWrite(ConsoleColor, "/> ");
+
+            Console.WriteLine(errorHelp);
+        }
+
+        if (errorHelp is null)
+        {
+            Console.WriteLine();
+        }
+
+        ColoredWriteLine(DarkGray, "     │");
+
+        return this;
+    }
+
+    public Error WithNote(string noteMessage)
+    {
+        ColoredWrite(DarkGray, "     │  ");
+
+        ColoredWrite(Green, "Note");
+
+        Console.WriteLine($": {noteMessage}");
+
+        ColoredWriteLine(DarkGray, "     │");
+
+        return this;
+    }
+
+    public void CloseError()
+    {
+        ColoredWriteLine(DarkGray, " ────╯\n");
+    }
+}

--- a/src/OtterkitErrorHandling.cs
+++ b/src/OtterkitErrorHandling.cs
@@ -2,7 +2,7 @@ namespace Otterkit;
 
 public static class ErrorHandler
 {
-    internal static bool Error = false;
+    internal static bool HasError = false;
     internal static Options Options = OtterkitCompiler.Options;
 
     public static class Compiler
@@ -33,36 +33,12 @@ public static class ErrorHandler
             Console.WriteLine($" {error}\n");
             Console.ResetColor();
 
-
-        }
-
-        public static void AttemptRecovery(string[] anchors)
-        {
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.Write("Attempting recovery: ");
-            Console.ForegroundColor = ConsoleColor.Gray;
-            Console.WriteLine($"""
-            Unexpected tokens will be ignored until a separator period or an anchor point is found 
-            (Anchors: {string.Join(", ", anchors)})
-
-            """);
-        }
-
-        public static void AttemptRecovery(TokenContext anchor)
-        {
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.Write("Attempting recovery: ");
-            Console.ForegroundColor = ConsoleColor.Gray;
-            Console.WriteLine($"""
-            Unexpected tokens will be ignored until a separator period or an anchor point is found 
-            (Anchor: {anchor})
-
-            """);
+            
         }
 
         public static void Report(string fileName, Token token, ErrorType error, params string[] expected)
         {
-            Error = true;
+            HasError = true;
 
             Console.ForegroundColor = ConsoleColor.Red;
 

--- a/src/OtterkitLexer/Token.Methods.cs
+++ b/src/OtterkitLexer/Token.Methods.cs
@@ -196,7 +196,7 @@ public sealed partial record Token
         // if none of the above, it's an identifier
         if (!TryValidateIdentifier(token))
         {
-            ErrorHandler.Error = true;
+            ErrorHandler.HasError = true;
         }
 
         return TokenType.Identifier;
@@ -281,7 +281,7 @@ public sealed partial record Token
         // If a lexing error has occured, terminate the compilation process.
         // We do not want the compiler to continue when the source code
         // potentially contains invalid Unicode.
-        if (ErrorHandler.Error) ErrorHandler.Terminate("lexing");
+        if (ErrorHandler.HasError) ErrorHandler.Terminate("lexing");
 
         return tokens;
     }


### PR DESCRIPTION
This PR contains the new error message API for Otterkit, as well as some refactoring needed to support the new API. This provides a modern look for Otterkit's error messages, which should massively improve the developer experience around debugging and fixing code issues, and also provide useful, easy to read information for the users.

Example of how the messages currently looks like:
![Screenshot 2023-03-24 112903](https://user-images.githubusercontent.com/73310001/227563262-b0405912-ea81-4264-91aa-48b85e117c02.png)


The current API is based around method chaining on a ref struct, meaning it shouldn't allocate any new objects on the heap (aside from the strings) and should perform reasonably well:
![Screenshot 2023-03-24 120611](https://user-images.githubusercontent.com/73310001/227564508-affd76f7-cd25-48eb-80d9-a83f48252858.png)

The API allows for the messages to be later extended with additional optional information. The above `.WithNote` method for example, is optional. Without the method, the error message would look like this:
![Screenshot 2023-03-24 113240](https://user-images.githubusercontent.com/73310001/227566502-2b4dcb2d-9065-4d04-9222-091961e776fb.png)

This should provide a great way to display useful information to experienced developers, while still being easy to read and understand for new developers.