### PR TITLE
Implement COBOL exceptions into C# system

### DIFF
--- a/Libraries/Otterkit.Runtime/src/Exceptions/CobolException.cs
+++ b/Libraries/Otterkit.Runtime/src/Exceptions/CobolException.cs
@@ -13,3 +13,11 @@ public readonly struct CobolException
         Severity = severity;
     }
 }
+
+public class RuntimeException : Exception
+{
+    public RuntimeException(string message) : base(message)
+    {
+
+    }
+}

--- a/Libraries/Otterkit.Runtime/src/Exceptions/ExceptionRegistry.cs
+++ b/Libraries/Otterkit.Runtime/src/Exceptions/ExceptionRegistry.cs
@@ -1,4 +1,5 @@
 namespace Otterkit.Runtime;
+using System.Text;
 
 // Implementing COBOL default/regular exceptions as a singleton containing a dictionary of exception status indicators
 public static class ExceptionRegistry
@@ -57,6 +58,18 @@ public static class ExceptionRegistry
         lastName.Fill(0);
 
         name.CopyTo(lastName);
+
+        StringBuilder message = new StringBuilder("Name: ");
+
+        string nameString = Encoding.UTF8.GetString(name);
+
+        message.Append(nameString);
+
+        int level = nameString.Split('-').Length - 1;
+        
+        message.AppendFormat(" Level: {0}", level);
+
+        throw new RuntimeException(message.ToString());
     }
 
     public static void DeactivateException(ReadOnlySpan<byte> name)


### PR DESCRIPTION
This is a PR to temporarily bridge the gap between COBOL and C# exceptions in order to finally get them to sort of work. COBOL-specific features are not implemented, they're just C# exceptions wired into the registry.